### PR TITLE
Update rubocop version in example app

### DIFF
--- a/examples/rails-5.0/Gemfile
+++ b/examples/rails-5.0/Gemfile
@@ -38,7 +38,7 @@ group :development do
   # Access an IRB console on exception pages or by using <%= console %> anywhere in the code.
   gem 'web-console'
   gem 'listen', '~> 3.0.5'
-  gem 'rubocop', '~> 0.44.1', require: false
+  gem 'rubocop', '>= 0.49.1', require: false
   gem 'model_base_generators', path: '../..'
 end
 

--- a/examples/rails-5.0/Gemfile.lock
+++ b/examples/rails-5.0/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: ../..
   specs:
-    model_base_generators (0.3.9)
+    model_base_generators (0.4.0)
       rails
 
 GEM
@@ -139,8 +139,9 @@ GEM
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
     orm_adapter (0.5.0)
-    parser (2.3.1.4)
-      ast (~> 2.2)
+    parallel (1.12.1)
+    parser (2.4.0.2)
+      ast (~> 2.3)
     powerpack (0.1.1)
     pry (0.10.4)
       coderay (~> 1.1.0)
@@ -193,7 +194,7 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rainbow (2.1.0)
+    rainbow (3.0.0)
     rake (11.3.0)
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
@@ -222,10 +223,11 @@ GEM
       rspec-mocks (~> 3.5.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    rubocop (0.44.1)
-      parser (>= 2.3.1.1, < 3.0)
+    rubocop (0.52.1)
+      parallel (~> 1.10)
+      parser (>= 2.4.0.2, < 3.0)
       powerpack (~> 0.1)
-      rainbow (>= 1.99.1, < 3.0)
+      rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.1)
@@ -268,7 +270,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (3.0.2)
       execjs (>= 0.3.0, < 3)
-    unicode-display_width (1.1.1)
+    unicode-display_width (1.3.0)
     uniform_notifier (1.10.0)
     warden (1.2.6)
       rack (>= 1.0)
@@ -310,7 +312,7 @@ DEPENDENCIES
   rails_best_practices
   rspec
   rspec-rails
-  rubocop (~> 0.44.1)
+  rubocop (>= 0.49.1)
   sass-rails (~> 5.0)
   simplecov
   simplecov-rcov

--- a/lib/model_base/version.rb
+++ b/lib/model_base/version.rb
@@ -1,3 +1,3 @@
 module ModelBase
-  VERSION = "0.3.9"
+  VERSION = "0.4.0"
 end


### PR DESCRIPTION
- Update rubocop version because of https://github.com/bbatsov/rubocop/issues/4336
- Bump up the version to 0.4.0